### PR TITLE
Added scripts for managing ec2 instances

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Scripts
+
+## How to use
+
+Set permissions and run:
+
+    chmod +x <script>
+    ./<script>

--- a/scripts/run_ec2_instance.sh
+++ b/scripts/run_ec2_instance.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+# Make sure AWS CLI is installed
+if ! hash aws 2>/dev/null; then
+    virtualenv .venv && source .venv/bin/activate
+    pip install awscli
+fi
+
+# Create a keypair. It is required for creating a new instance.
+# It can fail since keypair might exist already.
+aws ec2 create-key-pair --key-name my_keypair || true
+
+# Create a new instance using Ubuntu image
+EC2_RUN_RESULT=$(aws ec2 run-instances --instance-type t2.nano --count 1 --key my_keypair --image-id ami-79873901)

--- a/scripts/terminate_all_ec2_instances.sh
+++ b/scripts/terminate_all_ec2_instances.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+# Make sure AWS CLI is installed
+if ! hash aws 2>/dev/null; then
+    virtualenv .venv && source .venv/bin/activate
+    pip install awscli
+fi
+
+aws ec2 terminate-instances --instance-ids $(aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --output text)


### PR DESCRIPTION
Create a scripts directory and pushed there two scripts:

1. Run ec2 instances
2. Terminate [all] ec2 instances

The scripts assume only that user has executed 'aws configure'.