### PR TITLE
Validate vagrant command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,9 @@ localhost:5000
   * AMI ID
   * Subnet ID
   * Security Group with inbound ports for SSH and TCP port 5000
-* Adjust `Vagrantfile.local` with your configuration (see the Vagrantfile.local.example file for reference)
-* Install Vagrant AWS plugin
-```
-vagrant plugin install vagrant-aws
-```
+* Copy the file `aws.yml` to `aws.yml.local`
+* Adjust `aws.yml.local` with **your** configuration
+* Vagrant AWS plugin or any dependencies are done automatic on the **first run**
 * Launch the environment
 ```
 vagrant up stage

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,36 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# -------------------------------------------------------------
+# Exit if no environment name specified.
+# -------------------------------------------------------------
+
+environments = [
+    "dev",
+    "stage",
+    "prod"
+]
+commandsToCheck = [
+    "destroy",
+    "halt",
+    "provision",
+    "reload",
+    "resume",
+    "suspend",
+    "up"
+  ]
+  enteredCommand = ARGV[0]
+
+  # Is this one of the problem commands?
+  if commandsToCheck.include?(enteredCommand)
+    # Is this command lacking any other supported environments ? e.g. "vagrant destroy dev".
+    if not environments.include?ARGV[1]
+      puts "You must use 'vagrant #{ARGV[0]} " + environments.join("/") + "....'"
+      puts "Run 'vagrant status' to view VM names."
+      exit 1
+    end
+  end
+
 require 'yaml'
 AWS = YAML.load_file 'aws.yml'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,11 @@
 require 'yaml'
 AWS = YAML.load_file 'aws.yml'
 
+if File.exist?('aws.yml.local')
+    private_settings = YAML::load_file('aws.yml.local')
+    AWS.merge!(private_settings)
+end
+
 Vagrant.require_version ">= 2.2.4"
 
 Vagrant.configure("2") do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ commandsToCheck = [
   # Is this one of the problem commands?
   if commandsToCheck.include?(enteredCommand)
     # Is this command lacking any other supported environments ? e.g. "vagrant destroy dev".
-    if not environments.include?ARGV[1]
+    if not (environments.include?ARGV[1] or environments.include?ARGV[2])
       puts "You must use 'vagrant #{ARGV[0]} " + environments.join("/") + "....'"
       puts "Run 'vagrant status' to view VM names."
       exit 1


### PR DESCRIPTION
Validate vagrant command line parameters and  force user to enter dev/stage/prod - to prevent mistakes and errors like #152 