### PR TITLE
Fix Issue #181: The virtualenv created by Travis is a python 2 environment

### DIFF
--- a/provisioning/playbooks/site.yml
+++ b/provisioning/playbooks/site.yml
@@ -43,6 +43,7 @@
         requirements: "{{ homedir }}/requirements.txt"
         virtualenv: "{{ homedir }}/venv"
         virtualenv_command: virtualenv
+        virtualenv_python: python3
 
     - meta: flush_handlers
 


### PR DESCRIPTION
The solution was simply adding the 'virtualenv_python' key with the value'python3' in the 'site.yml' ansible playbook.
**And now in a new branch. :-)**