### PR TITLE
vault upgrade pip

### DIFF
--- a/vault_s2i/Dockerfile
+++ b/vault_s2i/Dockerfile
@@ -4,6 +4,7 @@ COPY . /
 
 ARG VAULT_GUEST_PORT
 RUN apk add --no-cache python3 && \
+    pip3 install --upgrade pip && \
     pip3 install -r /requirements.txt && \
     export VAULT_GUEST_PORT=$VAULT_GUEST_PORT && \
     j2 /config.hcl.j2 -o /vault/config/config.hcl


### PR DESCRIPTION
Upgrading pip when building vault image.
Removing the warning message - we are using an older version of pip when a newer one exists.