### PR TITLE
Add python imports prerequisites checks and python minimum version check

### DIFF
--- a/checkPythonVer.py
+++ b/checkPythonVer.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+
+def printPythonVer():
+    print("Python version")
+    print (sys.version)
+
+def checkPythonMinVer(major,minor):
+    if (sys.version_info[0] <  major):
+        print ("Found python ver " , sys.version_info[0], " with a minor version ", sys.version_info[1])
+        raise Exception("Must be using Python ", major,".",minor)
+    elif (sys.version_info[0] >= major and sys.version_info[1] < minor):
+        print ("Found python ver " , sys.version_info[0], " with a minor version ", sys.version_info[1])
+        raise Exception("Must be using Python ", major,".",minor)

--- a/spin.py
+++ b/spin.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
-import dotenv
-import vagrant
-import os
-import click
-from createPemFiles import SelfSignedCertificate, IsCertExist
+
+from checkPythonVer import checkPythonMinVer
+checkPythonMinVer(3,6)
+
+try:
+    import dotenv
+    import vagrant
+    import os
+    import click
+    from createPemFiles import SelfSignedCertificate, IsCertExist
+except ImportError:
+    with open("./requirements.txt", 'r') as fin:
+        print ("Make sure the following imports were done before running this program:")
+        print ("*********")
+        print (fin.read())
+        print ("*********:")
 
 
 def prepareEnvironmentVars(environementName):


### PR DESCRIPTION
Added 2 prerequisites checks:

1. Python ver must be bigger than 3.6 (configurable in spin.py)
2. On fresh install raise more informative message for running import and print prerequisites.txt
